### PR TITLE
Accept empty credentials

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -100,7 +100,11 @@ func (t *Transport) prepare(req *http.Request) error {
 	if err != nil {
 		return err
 	}
-	req.Header.Set("Authorization", cred.String())
+	
+	if cred != nil {
+		req.Header.Set("Authorization", cred.String())
+	}
+	
 	return nil
 }
 


### PR DESCRIPTION
Accept empty credentials from the digest hook to allow custom request transformations without setting digest Authorization headers