### PR TITLE
Add fallback method for challenge

### DIFF
--- a/challenge.go
+++ b/challenge.go
@@ -2,7 +2,6 @@ package digest
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"strings"
 
@@ -130,6 +129,9 @@ func (c *Challenge) String() string {
 	return Prefix + param.Format(pp...)
 }
 
+// ErrNoChallenge indicates that no WWW-Authenticate headers were found.
+var ErrNoChallenge = errors.New("no challenge found")
+
 // FindChallenge returns the first supported challenge in the headers
 func FindChallenge(h http.Header) (*Challenge, error) {
 	var last error
@@ -148,5 +150,5 @@ func FindChallenge(h http.Header) (*Challenge, error) {
 	if last != nil {
 		return nil, last
 	}
-	return nil, fmt.Errorf("no supported WWW-Authenticate headers")
+	return nil, ErrNoChallenge
 }

--- a/challenge_test.go
+++ b/challenge_test.go
@@ -1,6 +1,7 @@
 package digest
 
 import (
+	"errors"
 	"net/http"
 	"strconv"
 	"testing"
@@ -69,4 +70,11 @@ func TestFindChallenge(t *testing.T) {
 	chal, err := FindChallenge(headers)
 	assert.NilError(t, err)
 	assert.DeepEqual(t, chal, good)
+}
+
+func TestFindChallenge_NotFound(t *testing.T) {
+	_, err := FindChallenge(http.Header{})
+	if !errors.Is(err, ErrNoChallenge) {
+		t.Fatalf("not an expected error: %s, expected ErrNoChallenge", err.Error())
+	}
 }


### PR DESCRIPTION
If a bad implementation decides to not return a `WWW-Authenticate` on an expired credential, forget the cached challenge and start from scratch.