### PR TITLE
If there's no challenge, return the response

### DIFF
--- a/transport.go
+++ b/transport.go
@@ -2,7 +2,6 @@ package digest
 
 import (
 	"bytes"
-	"errors"
 	"io"
 	"net/http"
 	"sync"
@@ -69,7 +68,7 @@ func (t *Transport) save(res *http.Response) error {
 	//       to match against outgoing requests. We're currently ignoring
 	//       it and just matching the hostname.
 	host := res.Request.URL.Hostname()
-	if err == nil {
+	if chal != nil {
 		t.cache[host] = &cchal{c: chal}
 	} else {
 		// if save is being invoked, the existing cached challenge didn't work
@@ -164,7 +163,7 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	_ = res.Body.Close()
 	// save the challenge for future use
 	if err := t.save(res); err != nil {
-		if errors.Is(err, ErrNoChallenge) {
+		if err == ErrNoChallenge {
 			return res, nil
 		}
 		return nil, err

--- a/transport.go
+++ b/transport.go
@@ -2,6 +2,7 @@ package digest
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"net/http"
 	"sync"
@@ -163,6 +164,9 @@ func (t *Transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	_ = res.Body.Close()
 	// save the challenge for future use
 	if err := t.save(res); err != nil {
+		if errors.Is(err, ErrNoChallenge) {
+			return res, nil
+		}
 		return nil, err
 	}
 	// make a second copy of the request

--- a/transport.go
+++ b/transport.go
@@ -68,7 +68,7 @@ func (t *Transport) save(res *http.Response) error {
 	//       to match against outgoing requests. We're currently ignoring
 	//       it and just matching the hostname.
 	host := res.Request.URL.Hostname()
-	if chal != nil {
+	if err == nil {
 		t.cache[host] = &cchal{c: chal}
 	} else {
 		// if save is being invoked, the existing cached challenge didn't work

--- a/transport_test.go
+++ b/transport_test.go
@@ -1,7 +1,6 @@
 package digest
 
 import (
-	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -157,7 +156,8 @@ func TestTransportNoChallenge(t *testing.T) {
 	res1, err := client.Get(ts.URL)
 	assert.NilError(t, err)
 	assert.Equal(t, res1.StatusCode, http.StatusOK)
-	// second request should fail
-	_, err = client.Get(ts.URL)
-	assert.Assert(t, errors.Is(err, ErrNoChallenge))
+	// second request should return the status Unauthorized
+	res2, err := client.Get(ts.URL)
+	assert.NilError(t, err)
+	assert.Equal(t, res2.StatusCode, http.StatusUnauthorized)
 }


### PR DESCRIPTION
@dsonck92 I want to revisit the comment I made in your PR. I think the transport should be returning the response if there's no digest challenge. I'm pinging you because it would require you to change your `RetryTransport` implementation to check for `res.StatusCode == http.StatusUnauthorized` instead of `errors.Is(err, digest.ErrNoChallenge)`.