### PR TITLE
fix logic in transport test server

### DIFF
--- a/transport_test.go
+++ b/transport_test.go
@@ -35,6 +35,7 @@ func TestTransport(t *testing.T) {
 			cred2, err := Digest(chal, Options{
 				Method:   r.Method,
 				URI:      r.URL.RequestURI(),
+				Cnonce:   cred.Cnonce,
 				Count:    cred.Nc,
 				Username: username,
 				Password: password,
@@ -43,7 +44,7 @@ func TestTransport(t *testing.T) {
 				http.Error(w, err.Error(), http.StatusBadRequest)
 				return
 			}
-			authorized = cred.Response != cred2.Response
+			authorized = cred.Response == cred2.Response
 		}
 		if !authorized {
 			w.Header().Add("WWW-Authenticate", chal.String())


### PR DESCRIPTION
The challenge acceptance logic was inverted since the challenge would always fail as the server and client were using different cnonce values. Make sure they are using the same cnonce, and invert the authorized check.

The validity of the change can be tested by altering the test to use the wrong password. In the original state the test incorrectly continues to pass, but the new code will now fail in that case.

Please take a look.