### PR TITLE
Added uppercase to algorithm name

### DIFF
--- a/challenge.go
+++ b/challenge.go
@@ -52,7 +52,7 @@ func ParseChallenge(s string) (*Challenge, error) {
 		case "nonce":
 			c.Nonce = p.Value
 		case "algorithm":
-			c.Algorithm = p.Value
+			c.Algorithm = strings.ToUpper(p.Value)
 		case "stale":
 			c.Stale = strings.ToLower(p.Value) == "true"
 		case "opaque":
@@ -104,7 +104,7 @@ func (c *Challenge) String() string {
 	if c.Algorithm != "" {
 		pp = append(pp, param.Param{
 			Key:   "algorithm",
-			Value: c.Algorithm,
+			Value: strings.ToUpper(c.Algorithm),
 		})
 	}
 	if len(c.QOP) != 0 {

--- a/credentials.go
+++ b/credentials.go
@@ -48,7 +48,7 @@ func ParseCredentials(s string) (*Credentials, error) {
 		case "response":
 			c.Response = p.Value
 		case "algorithm":
-			c.Algorithm = p.Value
+			c.Algorithm = strings.ToUpper(p.Value)
 		case "cnonce":
 			c.Cnonce = p.Value
 		case "opaque":
@@ -96,7 +96,7 @@ func (c *Credentials) String() string {
 	if c.Algorithm != "" {
 		pp = append(pp, param.Param{
 			Key:   "algorithm",
-			Value: c.Algorithm,
+			Value: strings.ToUpper(c.Algorithm),
 		})
 	}
 	if c.QOP != "" {

--- a/digest.go
+++ b/digest.go
@@ -36,7 +36,7 @@ type Options struct {
 
 // CanDigest checks if the algorithm and qop are supported
 func CanDigest(c *Challenge) bool {
-	switch c.Algorithm {
+	switch strings.ToUpper(c.Algorithm) {
 	case "", "MD5", "SHA-256", "SHA-512", "SHA-512-256":
 	default:
 		return false
@@ -54,7 +54,7 @@ func Digest(chal *Challenge, o Options) (*Credentials, error) {
 		Nc:        o.Count,
 		Realm:     chal.Realm,
 		Nonce:     chal.Nonce,
-		Algorithm: chal.Algorithm,
+		Algorithm: strings.ToUpper(chal.Algorithm),
 		Opaque:    chal.Opaque,
 		Userhash:  chal.Userhash,
 	}


### PR DESCRIPTION
I had a problem with algorithm name when I got a response from asterisk after INVITE request. 

> Digest username="xxx", realm="asterisk", nonce="1729103338/662d65a084b88c6d2a745a9de086fa91", uri="sip:+xxxxx@yyyyy", algorithm=**md5**, cnonce="ef88a365ed38df27", opaque="753d1a557579147b", qop=auth, nc=00000001, response="3681b63e5d9c3bb80e5350e2783d7b88"

Asterisk returned me 'md5' instead "MD5" and digest doesn't recognize a response and return false instead true. I made a small hack and upper all entry. 