### PR TITLE
add support for lowercase digest algorithms

### DIFF
--- a/digest.go
+++ b/digest.go
@@ -36,7 +36,8 @@ type Options struct {
 
 // CanDigest checks if the algorithm and qop are supported
 func CanDigest(c *Challenge) bool {
-	switch c.Algorithm {
+	algorithm := strings.ToUpper(c.Algorithm)
+	switch algorithm {
 	case "", "MD5", "SHA-256", "SHA-512", "SHA-512-256":
 	default:
 		return false
@@ -60,7 +61,8 @@ func Digest(chal *Challenge, o Options) (*Credentials, error) {
 	}
 	// we re-use the same hash.Hash
 	var h hash.Hash
-	switch cred.Algorithm {
+	algorithm := strings.ToUpper(cred.Algorithm)
+	switch algorithm {
 	case "", "MD5":
 		h = md5.New()
 	case "SHA-256":


### PR DESCRIPTION
Thank you for the library! I've been using it to handle authentication for IP cameras, but encountered an issue while trying to authenticate with an Acti IP camera. Here is the code:
```go
import (
	"bytes"
	"fmt"
	"io"
	"net/http"
	"net/url"

	"github.com/icholy/digest"
)

type Client struct {
	baseURL  *url.URL
	username string
	password string
}

func NewClient(host, username, password string) (*Client, error) {
	u, err := url.Parse("http://" + host)
	if err != nil {
		return nil, fmt.Errorf("error parsing URL: %v", err)
	}
	return &Client{
		baseURL:  u,
		username: username,
		password: password,
	}, nil
}

func (c Client) Send(request []byte, uriPath string) ([]byte, error) {
	u, err := url.Parse(c.baseURL.String() + "/" + uriPath)
	if err != nil {
		return nil, fmt.Errorf("error parsing URL: %v", err)
	}

	req, err := http.NewRequest("POST", u.String(), bytes.NewBuffer(request))
	if err != nil {
		return nil, fmt.Errorf("error creating HTTP request: %v", err)
	}

	req.Header.Set("Content-Type", "application/soap+xml; charset=utf-8")
	req.Header.Set("User-Agent", "agent/1.0")

	client := &http.Client{
		Transport: &digest.Transport{
			Username: c.username,
			Password: c.password,
		},
	}
	resp, err := client.Do(req)
	if err != nil {
		return nil, fmt.Errorf("error sending HTTP request: %v", err)
	}
	defer resp.Body.Close()

	body, err := io.ReadAll(resp.Body)
	if err != nil {
		return nil, fmt.Errorf("error reading response body: %v", err)
	}

	if resp.StatusCode != http.StatusOK {
		return nil, fmt.Errorf("bad response status: %v, body: %s", resp.Status, string(body))
	}

	return body, nil
}
```
The returned error wasn't too helpful:
```shell
error reading response body: http: read on closed response body
```
After some investigation, it turned out that the initial digest 401 response from the camera had a lowercase `md5` and the code only checks against an uppercase `MD5`
```shell
curl ... -v
< HTTP/1.1 401 Unauthorized
< Server: Httpd v1.0 05may2008
< Content-Type: application/soap+xml; charset=utf-8
< Date: Fri, 22 Nov 2024 13:59:20 GMT
< Last-Modified: Fri, 22 Nov 2024 13:59:20 GMT
< Accept-Ranges: bytes
< Connection: Close
< Cache-Control: no-cache,no-store
< WWW-Authenticate: Basic realm="Http Server"
< WWW-Authenticate: Digest realm="Http Server", nonce="f0ef6bfecc196903b2befc6a66b59b8a", algorithm=md5, qop="auth"

```